### PR TITLE
Types should always have the entry "default".

### DIFF
--- a/widgets/JsTree.php
+++ b/widgets/JsTree.php
@@ -78,7 +78,10 @@ class JsTree extends InputWidget
     /**
      * @var array Stores all defaults for the types plugin
      */
-    public $types = [];
+    public $types = [
+        '#' => [],
+        'default' => [],
+    ];
 
     /**
      * @inheritdoc


### PR DESCRIPTION
According to jsTree (source code) the types is always expected to have an entry with the name "default". Otherwise you get an uncaught exception.
